### PR TITLE
build: update raft-proto to make it compatible with new protoc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,8 +332,8 @@ checksum = "da3d0613473597a01860f0f802ab18bb019b1d21e33d6a9a0b3c8870084893e5"
 dependencies = [
  "derive-new",
  "prost 0.11.9",
- "prost-build 0.11.9",
- "prost-types 0.11.9",
+ "prost-build",
+ "prost-types",
  "protobuf",
  "tempfile",
 ]
@@ -433,7 +433,7 @@ dependencies = [
  "prost 0.9.0",
  "prost-derive 0.9.0",
  "protobuf",
- "protobuf-build 0.15.1",
+ "protobuf-build",
  "raft-proto",
 ]
 
@@ -633,26 +633,6 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prost 0.9.0",
- "prost-types 0.9.0",
- "regex",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-build"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
@@ -666,7 +646,7 @@ dependencies = [
  "petgraph",
  "prettyplease",
  "prost 0.11.9",
- "prost-types 0.11.9",
+ "prost-types",
  "regex",
  "syn 1.0.109",
  "tempfile",
@@ -701,16 +681,6 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
-dependencies = [
- "bytes",
- "prost 0.9.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
@@ -730,22 +700,6 @@ dependencies = [
 
 [[package]]
 name = "protobuf-build"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2be70fa994657539e3c872cc54363c9bf28b0d7a7f774df70e9fd760df3bc4"
-dependencies = [
- "bitflags 1.3.2",
- "proc-macro2",
- "prost-build 0.9.0",
- "protobuf",
- "protobuf-codegen",
- "quote",
- "regex",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "protobuf-build"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c852d9625b912c3e50480cdc701f60f49890b5d7ad46198dd583600f15e7c6ec"
@@ -753,7 +707,7 @@ dependencies = [
  "bitflags 1.3.2",
  "grpcio-compiler",
  "proc-macro2",
- "prost-build 0.11.9",
+ "prost-build",
  "protobuf",
  "protobuf-codegen",
  "protobuf-src",
@@ -792,13 +746,13 @@ dependencies = [
 [[package]]
 name = "raft-proto"
 version = "0.7.0"
-source = "git+https://github.com/tikv/raft-rs?rev=95c532612ee6a83591fce9a8b51d6afe87b58835#95c532612ee6a83591fce9a8b51d6afe87b58835"
+source = "git+https://github.com/tikv/raft-rs?rev=2fbeee5b89b22c392da39435b79be9896acedd1d#2fbeee5b89b22c392da39435b79be9896acedd1d"
 dependencies = [
  "bytes",
  "lazy_static",
- "prost 0.9.0",
+ "prost 0.11.9",
  "protobuf",
- "protobuf-build 0.13.0",
+ "protobuf-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,6 @@ grpcio = { version = "0.*", default-features = false }
 protobuf-build = { version = "0.*", default-features = false }
 
 [patch.crates-io]
-raft-proto = { git = "https://github.com/tikv/raft-rs", rev="95c532612ee6a83591fce9a8b51d6afe87b58835"}
+raft-proto = { git = "https://github.com/tikv/raft-rs", rev="2fbeee5b89b22c392da39435b79be9896acedd1d"}
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev="82b49fea7e696fd647b5aca0a6c6ec944eab3189" }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev="82b49fea7e696fd647b5aca0a6c6ec944eab3189" }

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ go: check
 	GO111MODULE=on go build ./pkg/...
 
 rust: check
-	cargo check && \
-	cargo check --no-default-features --features prost-codec
+	# We do not check prost build here as it's not used and the prost version of kvproto,raft-proto,grpc-io,protobuf-build are different from each other.
+	cargo check
 
 c++: check
 	mkdir -p kvprotobuild && cd kvprotobuild && cmake ../cpp -DCMAKE_PREFIX_PATH=$$GRPC_INSTALL_PATH && make


### PR DESCRIPTION
update raft-proto to newest version to let it depend new protobuf-build, so kvproto can be compatible with newest protoc.